### PR TITLE
Automate gem release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '45 23 14 * *'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.4'
+          bundler-cache: true
+      - name: Refresh database
+        run: bin/dbiputil-refresh
+      - name: Commit refreshed database
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Automated DB refresh" || echo "No changes to commit"
+          git push
+      - name: Release gem
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: bundle exec rake release

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 DbipUtil includes DB-IP Lite databases and a simple interface to them, based on `maxmind-db` gem.
 
-It is automatically updated every month to refresh the database. Ensure to comply with the database licensing terms below in this document.
+The included databases are refreshed automatically. A GitHub Actions workflow runs `bin/dbiputil-refresh` and then `rake release` at **00:45&nbsp;GMT+1 on the 15th of every month** to publish a new gem version. Ensure to comply with the database licensing terms below in this document.
 
 ## Installation
 
@@ -44,7 +44,7 @@ The databases are documented here:
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. If you need to trigger a release manually, run `bin/dbiputil-refresh` and then `bundle exec rake release`. This will create a git tag for the version, push commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add a GitHub Action that refreshes the DB and runs `rake release`
- document the monthly automated release and manual release steps

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_6875888073f4832a87c7edaf84cfaf0e