### PR TITLE
Add CI matrix for Ruby versions and OSes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        ruby:
-          - '3.4.4'
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        ruby: ['3.1', '3.2', '3.3', '3.4.4']
 
     steps:
       - uses: actions/checkout@v4
@@ -25,3 +26,4 @@ jobs:
           bundler-cache: true
       - name: Run the default task
         run: bundle exec rake
+        shell: bash


### PR DESCRIPTION
## Summary
- expand GitHub Actions test matrix for Ruby 3.1+ and across OSes

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_68758c77994c832a98847d406400ee53