### PR TITLE
Update release schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   workflow_dispatch:
   schedule:
-    - cron: '45 23 14 * *'
+    - cron: '0 0 2 * *'
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 DbipUtil includes DB-IP Lite databases and a simple interface to them, based on `maxmind-db` gem.
 
-The included databases are refreshed automatically. A GitHub Actions workflow runs `bin/dbiputil-refresh` and then `rake release` at **00:45&nbsp;GMT+1 on the 15th of every month** to publish a new gem version. Ensure to comply with the database licensing terms below in this document.
+The included databases are refreshed automatically. A GitHub Actions workflow runs `bin/dbiputil-refresh` and then `rake release` at **00:00&nbsp;GMT on the 2nd of every month** to publish a new gem version. Ensure to comply with the database licensing terms below in this document.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- change GitHub Actions release cron to run at 00:00 GMT on the 2nd day of each month
- update README to match the new automated release schedule

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_687590f2012c832abfebf8d91da68585