### PR TITLE
Fetch DBs from latest gem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Provision databases
+        run: bin/dbiputil-provision
       - name: Run the default task
         run: bundle exec rake
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Provision databases
-        run: bin/dbiputil-provision
+        run: ruby bin/dbiputil-provision
+        shell: bash
       - name: Run the default task
         run: bundle exec rake
         shell: bash

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The databases are documented here:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. If you only need the databases without downloading them from DB-IP directly, run `bin/dbiputil-provision` which extracts them from the latest released gem on RubyGems.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. If you only need the databases without downloading them from DB-IP directly, run `ruby bin/dbiputil-provision` which extracts them from the latest released gem on RubyGems.
 
 To install this gem onto your local machine, run `bundle exec rake install`. If you need to trigger a release manually, run `bin/dbiputil-refresh` and then `bundle exec rake release`. This will create a git tag for the version, push commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The databases are documented here:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. If you only need the databases without downloading them from DB-IP directly, run `bin/dbiputil-provision` which extracts them from the latest released gem on RubyGems.
 
 To install this gem onto your local machine, run `bundle exec rake install`. If you need to trigger a release manually, run `bin/dbiputil-refresh` and then `bundle exec rake release`. This will create a git tag for the version, push commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/bin/dbiputil-provision
+++ b/bin/dbiputil-provision
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+require "rubygems/package"
+require "fileutils"
+require "tmpdir"
+
+GEM_NAME = "dbip_util"
+
+def latest_version
+  uri = URI("https://rubygems.org/api/v1/gems/#{GEM_NAME}.json")
+  JSON.parse(Net::HTTP.get(uri))["version"]
+end
+
+version = latest_version
+
+base_dir = File.expand_path(File.join(__dir__, "..", "lib", "dbip_util"))
+Dir.chdir(base_dir) do
+  Dir.mktmpdir do |tmp|
+    gem_path = File.join(tmp, "#{GEM_NAME}-#{version}.gem")
+    File.binwrite(gem_path, Net::HTTP.get(URI("https://rubygems.org/downloads/#{GEM_NAME}-#{version}.gem")))
+    extract_dir = File.join(tmp, "pkg")
+    Gem::Package.new(gem_path).extract_files(extract_dir)
+    %w[country city asn].each do |type|
+      FileUtils.mkdir_p("db")
+      src = File.join(extract_dir, "lib", "dbip_util", "db", "dbip-#{type}-lite.mmdb")
+      FileUtils.cp(src, File.join("db", "dbip-#{type}-lite.mmdb"))
+    end
+  end
+end

--- a/lib/dbip_util.rb
+++ b/lib/dbip_util.rb
@@ -35,8 +35,8 @@ module DbipUtil
   end
 
   def ensure_provisioned!
-    # Check for a sample database. If not present, provision it.
-    system "#{__dir__}/../bin/dbiputil-refresh" unless File.exist?(db_path(:country))
+    # Check for a sample database. If not present, provision it from Rubygems.
+    system "#{__dir__}/../bin/dbiputil-provision" unless File.exist?(db_path(:country))
   rescue StandardError
     warn "Couldn't provision a database! Use a `dbip_util` gem from Rubygems, as it includes a database."
     raise


### PR DESCRIPTION
## Summary
- add `bin/dbiputil-provision` to unpack the databases from the newest published gem
- update README with local provisioning instructions
- adjust automatic provisioning logic to use the new tool
- run the new tool in CI before tests

## Testing
- `bundle exec rake spec`
- `bundle exec rubocop`
- `bundle exec rake`


------
https://chatgpt.com/codex/tasks/task_e_687590997d84832a9cc91701f3287034